### PR TITLE
ci: manage MLflow lifecycle with docker compose in workflow

### DIFF
--- a/.github/workflows/mlops-ci-workflow.yaml
+++ b/.github/workflows/mlops-ci-workflow.yaml
@@ -1,0 +1,56 @@
+name: MLops CI
+
+
+on: 
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+
+jobs:
+  workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.5
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      
+      - name: Run Data Processing
+        run: |
+          python src/data/run_processing.py \
+            --input data/raw/house_data.csv \
+            --output data/processed/cleaned_house_data.csv
+
+      - name: Do Feature Engineering
+        run: |
+          python src/features/engineer.py \
+            --input data/processed/cleaned_house_data.csv \
+            --output data/processed/featured_house_data.csv \
+            --preprocessor models/trained/preprocessor.pkl
+      
+      - name: Setup MLflow
+        run: |
+          docker compose -f deployment/mlflow/docker-compose.yaml up -d
+
+      - name: Train the Model
+        run: |
+          python src/models/train_model.py \
+            --config configs/model_config.yaml \
+            --data data/processed/featured_house_data.csv \
+            --models-dir models \
+            --mlflow-tracking-uri http://localhost:5555
+      
+      - name: Cleanup MLflow
+        run: |
+          docker compose -f deployment/mlflow/docker-compose.yaml down


### PR DESCRIPTION
## What this PR does
This PR updates the MLflow setup/cleanup steps in the CI workflow (used in the O'reilly's video lesson) to use Docker Compose for container lifecycle management.

## Changes made
- Replaced manual MLflow startup commands (`docker pull` + `docker run`) with:
  - `docker compose -f deployment/mlflow/docker-compose.yaml up -d`
- Replaced manual cleanup commands (`docker stop`, `docker rm`, `docker rmi`) with:
  - `docker compose -f deployment/mlflow/docker-compose.yaml down`

## Why
- Keeps CI aligned with the project’s existing `deployment/mlflow/docker-compose.yaml` definition.
- Simplifies maintenance by managing MLflow config in one place.
- Makes cleanup safer and cleaner (no forced image removal in CI).
- Avoids issues from command drift between local/dev and CI environments.

## Expected impact
- No behavior change in model training logic.
- More reliable and reproducible MLflow startup/teardown in GitHub Actions.
